### PR TITLE
Fix: Duplicate key in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "alwaysStrict": true,
     "skipLibCheck": true,
     "module": "None",
-    "allowJs": "true",
     "target": "es2017",
     "jsx": "react",
     "allowJs": true,


### PR DESCRIPTION
#### Description of Change

`tsconfig.json` has a duplicate `allowJs` key, which also has an invalid value. This PR removes it and leaves the correct one.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.
-->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] PR title follows semantic [commit guidelines](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)

#### Release Notes

Notes: none
